### PR TITLE
bpf: Fix mask generation for 32-bit narrow loads of 64-bit fields

### DIFF
--- a/kernel/bpf/verifier.c
+++ b/kernel/bpf/verifier.c
@@ -17414,7 +17414,7 @@ static int convert_ctx_accesses(struct bpf_verifier_env *env)
 					insn_buf[cnt++] = BPF_ALU64_IMM(BPF_RSH,
 									insn->dst_reg,
 									shift);
-				insn_buf[cnt++] = BPF_ALU64_IMM(BPF_AND, insn->dst_reg,
+				insn_buf[cnt++] = BPF_ALU32_IMM(BPF_AND, insn->dst_reg,
 								(1ULL << size * 8) - 1);
 			}
 		}


### PR DESCRIPTION
Pull request for series with
subject: bpf: Fix mask generation for 32-bit narrow loads of 64-bit fields
version: 1
url: https://patchwork.kernel.org/project/netdevbpf/list/?series=744458
