### PR TITLE
bpf/xdp: optimize bpf_xdp_pointer to avoid reading sinfo

### DIFF
--- a/net/core/filter.c
+++ b/net/core/filter.c
@@ -3948,20 +3948,24 @@ void bpf_xdp_copy_buf(struct xdp_buff *xdp, unsigned long off,
 
 void *bpf_xdp_pointer(struct xdp_buff *xdp, u32 offset, u32 len)
 {
-	struct skb_shared_info *sinfo = xdp_get_shared_info_from_buff(xdp);
 	u32 size = xdp->data_end - xdp->data;
+	struct skb_shared_info *sinfo;
 	void *addr = xdp->data;
 	int i;
 
 	if (unlikely(offset > 0xffff || len > 0xffff))
 		return ERR_PTR(-EFAULT);
 
+	if (likely((offset < size))) /* linear area */
+		goto out;
+
+	if (likely(!xdp_buff_has_frags(xdp)))
+		goto out;
+
 	if (offset + len > xdp_get_buff_len(xdp))
 		return ERR_PTR(-EINVAL);
 
-	if (offset < size) /* linear area */
-		goto out;
-
+	sinfo = xdp_get_shared_info_from_buff(xdp);
 	offset -= size;
 	for (i = 0; i < sinfo->nr_frags; i++) { /* paged area */
 		u32 frag_size = skb_frag_size(&sinfo->frags[i]);


### PR DESCRIPTION
Pull request for series with
subject: bpf/xdp: optimize bpf_xdp_pointer to avoid reading sinfo
version: 1
url: https://patchwork.kernel.org/project/netdevbpf/list/?series=752777
